### PR TITLE
made some progress in windowB accessibility - not entirely there yet though

### DIFF
--- a/scripts/htmlBlocks.js
+++ b/scripts/htmlBlocks.js
@@ -36,7 +36,7 @@ block.windowCNameplate = function(nameplate, userPhoto, userName) {
 block.windowCSection = function(sectionClass, sectionID, sectionName) {
    return `<section class="${sectionClass}">
             <input type='checkbox' id='${sectionID}' name='dropdown' class='checkbox srOnly'>
-            <label for='${sectionID}' class='profileHeader'>- ${sectionName} -</label>
+            <label for='${sectionID}' class='profileHeader' aria-label='Click here to show more information for ${sectionName}'>- ${sectionName} -</label>
             <div class='hiddenContents'>
                
             </div>

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -182,7 +182,10 @@ idApp.displayChoices = function(array, currentWindow, nextWindow) {
       const hiddenBio = $('<div>').attr('class', 'hiddenContents').append(bioHeader, shortBio)
 
       const plusIcon = $('<i>').attr('class', 'fas fa-plus')
-      const closeButton = $('<button>').attr({class: 'closeButton', title: 'More Info', type: 'button'}).append(plusIcon);
+      const closeButton = $('<button>').attr({
+         class: 'closeButton',
+         title: 'More Information',
+         type: 'button'}).attr('aria-label', 'Click here to show more information about this identity').append(plusIcon);
 
       const optionContainer = $('<div>').attr('class', 'optionContainer').append(imageContainer, textContainer, hiddenBio);
       const radioInput = $('<input>').attr({

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -62,7 +62,7 @@ idApp.eventListeners = function() {
    })
 
    // Event Listener #3B to hide the extra info by clicking the X button
-   $main.on('click', '.fa-plus', function() {
+   $main.on('click', '.closeButton', function() {
       $(this).toggleClass('active');
       $(this).siblings('.optionContainer').find('.hiddenContents').toggleClass('displayContents')
    })
@@ -179,11 +179,12 @@ idApp.displayChoices = function(array, currentWindow, nextWindow) {
       userBio.generateBio(identityObject.name);
       const bioHeader = $('<h3>').text('Sample Personality')
       const shortBio = $('<p>').text(userBio.bioResults[0].shortBio)
-      const hiddenStuffs = $('<div>').attr('class', 'hiddenContents').append(bioHeader, shortBio)
+      const hiddenBio = $('<div>').attr('class', 'hiddenContents').append(bioHeader, shortBio)
 
-      const closeButton = $('<i>').attr('class', 'fas fa-plus')
+      const plusIcon = $('<i>').attr('class', 'fas fa-plus')
+      const closeButton = $('<button>').attr({class: 'closeButton', title: 'More Info', type: 'button'}).append(plusIcon);
 
-      const optionContainer = $('<div>').attr('class', 'optionContainer').append(imageContainer, textContainer, hiddenStuffs);
+      const optionContainer = $('<div>').attr('class', 'optionContainer').append(imageContainer, textContainer, hiddenBio);
       const radioInput = $('<input>').attr({
          type: 'radio', 
          id: `${identityObject.id}`, 
@@ -282,6 +283,7 @@ idApp.finalDisplay = function(array) {
 // Init Function 
 idApp.init = function(){
    idApp.eventListeners();
+   console.log('Oh, hello there! Wondering why the keyboard tabbing on the options page is wonky? So are we! This is a bug we are aware of and are working to fix, as we want to make sure our application is fully accessible to all users. Stay tuned for a fix! 🔥');
 }
 
 // Document Ready

--- a/styles/scss/_windowB.scss
+++ b/styles/scss/_windowB.scss
@@ -77,16 +77,18 @@
                 margin: 10px 0 20px 0;
             }
         }        
-        
-        .fa-plus {
+
+        .closeButton {
             position: absolute;
-            color: $fontMainColor;
-            font-size: 2rem;
             top: 0;
             right: 0;
             z-index: 10;
-            padding: 10px;
             transition: transform .5s;
+            border-radius: 50%;
+            padding: 7px 10px;
+            background: $accentBlue;
+            border: $bgColor;
+            color: $bgColor;
         }
     
         .active {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -554,18 +554,20 @@ main {
   margin: 10px 0 20px 0;
 }
 
-.windowB fieldset .fa-plus {
+.windowB fieldset .closeButton {
   position: absolute;
-  color: #f1faee;
-  font-size: 2rem;
   top: 0;
   right: 0;
   z-index: 10;
-  padding: 10px;
   -webkit-transition: -webkit-transform .5s;
   transition: -webkit-transform .5s;
   transition: transform .5s;
   transition: transform .5s, -webkit-transform .5s;
+  border-radius: 50%;
+  padding: 7px 10px;
+  background: #a8dadc;
+  border: #0f1c2e;
+  color: #0f1c2e;
 }
 
 .windowB fieldset .active {


### PR DESCRIPTION
Oh hello!

Here are zee changes:
- wrapped the "fa-plus" icon in a <button>, which makes it accessible via tabbing 
- changed the styling for "fa-plus" in _windowB.scss so that it is now for the button (with a class of .closeButton)
- line182 - changed the variable "hiddenStuffs" to "hiddenBio" (thought I had done this last time, but I stand corrected haha)

Tabbing now semi-works on windowB. That same issue that we looked at earlier still persists - where once a user makes a selection via tabbing, they cannot choose another option (because the focus only goes from button-to-button after that, and inexplicably skips over the radio inputs 🤷‍♀️).

To be continued! 

